### PR TITLE
Update README.md with valid register URL and data load information

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ There may need to be modifications to the included example config files (`.env`)
 
 By default Dispatch does not come with any data. If you're looking for some example data, please use the postgres dump file located [here](https://github.com/Netflix/dispatch/blob/master/data/dispatch-sample-data.dump) to load example data.
 
+Note: when running the `install.sh` file, you will be asked whether to load this database dump, or to initialize a new database.
+
 ### Starting with a clean database
 
-If you decide to start with a clean database, you will need a user. To create a user, go to http://localhost:8000/register.
+If you decide to start with a clean database, you will need a user. To create a user, go to http://localhost:8000/default/auth/register.
 
 ## Securing Dispatch with SSL/TLS
 

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ if [ ! $CI ]; then
     docker-compose run -e "PGPASSWORD=$POSTGRES_PASSWORD" --rm postgres createdb -h $DATABASE_HOSTNAME -p $DATABASE_PORT -U $POSTGRES_USER $DATABASE_NAME
     echo "Loading example data to the database..."
     docker-compose run -e "PGPASSWORD=$POSTGRES_PASSWORD" -v "$(pwd)/$DISPATCH_DB_SAMPLE_DATA_FILE:/$DISPATCH_DB_SAMPLE_DATA_FILE:Z" --rm postgres psql -h $DATABASE_HOSTNAME -p $DATABASE_PORT -U $POSTGRES_USER -d $DATABASE_NAME -f "/$DISPATCH_DB_SAMPLE_DATA_FILE"
-    echo "Example data loaded. Navigate to /register and create a new user."
+    echo "Example data loaded. Navigate to /default/auth/register and create a new user."
   else
     echo "Initializing the database"
     docker-compose run --rm web database init


### PR DESCRIPTION
The URL for registering users has changed. And a bit more information is provided around automatically loading the database dump when running the `./install.sh` command